### PR TITLE
chore: update ci docker images to slim from slim-bullseye

### DIFF
--- a/.github/workflows/deploy_docs.yaml
+++ b/.github/workflows/deploy_docs.yaml
@@ -11,7 +11,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     container:
-      image: python:3.11-slim
+      image: python:3.12-slim
 
     steps:
       - name: Git setup

--- a/.github/workflows/deploy_docs.yaml
+++ b/.github/workflows/deploy_docs.yaml
@@ -11,7 +11,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     container:
-      image: python:3.11-slim-bullseye
+      image: python:3.11-slim
 
     steps:
       - name: Git setup

--- a/.github/workflows/tests_and_linters_and_docs_build.yaml
+++ b/.github/workflows/tests_and_linters_and_docs_build.yaml
@@ -9,7 +9,7 @@ jobs:
   linters:
     runs-on: ubuntu-latest
     container:
-      image: python:3.11-slim
+      image: python:3.12-slim
 
     steps:
       - name: Git setup
@@ -31,7 +31,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     container:
-      image: python:3.11-slim
+      image: python:3.12-slim
 
     steps:
       - name: Git setup
@@ -81,7 +81,7 @@ jobs:
     # Only build the docs and don't deploy them
     runs-on: ubuntu-latest
     container:
-      image: python:3.11-slim
+      image: python:3.12-slim
 
     steps:
       - name: Git setup

--- a/.github/workflows/tests_and_linters_and_docs_build.yaml
+++ b/.github/workflows/tests_and_linters_and_docs_build.yaml
@@ -9,7 +9,7 @@ jobs:
   linters:
     runs-on: ubuntu-latest
     container:
-      image: python:3.11-slim-bullseye
+      image: python:3.11-slim
 
     steps:
       - name: Git setup
@@ -31,7 +31,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     container:
-      image: python:3.11-slim-bullseye
+      image: python:3.11-slim
 
     steps:
       - name: Git setup
@@ -81,7 +81,7 @@ jobs:
     # Only build the docs and don't deploy them
     runs-on: ubuntu-latest
     container:
-      image: python:3.11-slim-bullseye
+      image: python:3.11-slim
 
     steps:
       - name: Git setup

--- a/.github/workflows/tox_tests.yaml
+++ b/.github/workflows/tox_tests.yaml
@@ -8,7 +8,7 @@ jobs:
   tox_py311:
     runs-on: ubuntu-latest
     container:
-      image: python:3.11-slim-bullseye
+      image: python:3.11-slim
 
     steps:
       - name: Git setup
@@ -28,7 +28,7 @@ jobs:
   tox_py312:
     runs-on: ubuntu-latest
     container:
-      image: python:3.12-slim-bullseye
+      image: python:3.12-slim
 
     steps:
       - name: Git setup
@@ -48,7 +48,7 @@ jobs:
   tox_py313:
     runs-on: ubuntu-latest
     container:
-      image: python:3.13-slim-bullseye
+      image: python:3.13-slim
 
     steps:
       - name: Git and compiler setup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Release 0.1.2
 
 - Minor updates to improve code readability.
+- Updating python images used in ci.
 
 ## Release 0.1.1
 


### PR DESCRIPTION
Update the docker image in the ci from slim to slim-bullseye to match `mlip`. @chrbrunk perhaps it also wouldn't be absurd to upgrade the Python version to match.