### PR TITLE
fix: add missing continue

### DIFF
--- a/src/mlipaudit/benchmarks/scaling/scaling.py
+++ b/src/mlipaudit/benchmarks/scaling/scaling.py
@@ -241,6 +241,7 @@ class ScalingBenchmark(Benchmark):
                         failed=True,
                     )
                 )
+                continue
 
             num_steps_per_episode = (
                 self._md_kwargs["num_steps"] // self._md_kwargs["num_episodes"]


### PR DESCRIPTION
## Summary

We need to skip analyzing the output of systems where the simulation failed as part of the scaling test, i.e. if the simulation returned `None` in the `run_model` phase. 