### PR TITLE
ci: enforce develop-only PRs into main and update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,11 @@
 State the reason for your Pull Request and explain
 any changes you have made.
 
+> **Branch target.** All regular PRs must target `develop`. PRs into `main` are
+> only accepted from `develop` and are exclusively used for releases — they will
+> be blocked by CI otherwise. See the
+> [release pipeline](https://www.notion.so/instadeep/Release-pipeline-336ed6e1dfc480288045ef94266cab48).
+
 ## Checklist for adding a new benchmark
 
 - [ ] Benchmark class is fully implemented, including
@@ -16,7 +21,8 @@ testing pattern.
 - [ ] The UI code is added and up-to-date and has been tested.
 - [ ] Our license has been added to any Python file.
 
-## Checklist for a release PR (merge to main)
+## Checklist for a release PR (`develop` → `main`)
 
-- [ ] CHANGELOG has been updated
-- [ ] Version number as been increased
+- [ ] PR base is `main` and head is `develop`
+- [ ] Version in `pyproject.toml` has been bumped
+- [ ] `CHANGELOG.md` has been updated

--- a/.github/workflows/base_branch_guard.yaml
+++ b/.github/workflows/base_branch_guard.yaml
@@ -1,0 +1,20 @@
+name: base-branch-guard
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  base-branch-guard:
+    name: base-branch-guard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure PRs into main come from develop
+        run: |
+          if [ "${{ github.head_ref }}" != "develop" ]; then
+            echo "PRs into 'main' must come from 'develop' (got '${{ github.head_ref }}')."
+            echo "See https://www.notion.so/instadeep/Release-pipeline-336ed6e1dfc480288045ef94266cab48"
+            exit 1
+          fi
+          echo "OK: head branch is 'develop'."

--- a/.github/workflows/base_branch_guard.yaml
+++ b/.github/workflows/base_branch_guard.yaml
@@ -9,6 +9,7 @@ jobs:
   base-branch-guard:
     name: base-branch-guard
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Ensure PRs into main come from develop
         run: |

--- a/README.md
+++ b/README.md
@@ -142,6 +142,15 @@ this library.
 
 ## 🤝 Contributing
 
+### Branching model
+
+All day-to-day development targets the `develop` branch, which is the default
+branch of this repository. The `main` branch tracks the latest released version
+only — it receives changes exclusively via release PRs from `develop`, and
+non-release PRs into `main` are blocked by CI.
+
+### Setting up your environment
+
 To work directly in this repository, run
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/base_branch_guard.yaml` — fails any PR targeting `main` whose `head_ref` is not `develop`, so `main` can only receive code via release PRs from `develop`.
- Updates `.github/pull_request_template.md` to reflect the `develop`-default branching model and the release-PR checklist.

This is paired with two repository rulesets (already configured):
- **Default branch** (targets `~DEFAULT_BRANCH` = `develop`): PR with 1 approval, required checks (`tests`, `linters`).
- **Main release-only** (targets `refs/heads/main`): PR with 1 approval, required checks (`tests`, `linters`, `base-branch-guard`).

The `base-branch-guard` required check on the `Main release-only` ruleset is what makes the develop-only constraint enforceable — this PR adds the workflow that produces that check.

## Test plan
- [ ] Verify the workflow appears on this PR (it should NOT run here, since the base is `develop`, not `main`).
- [ ] After merge into `develop`, open a throwaway PR from any non-`develop` branch into `main` and confirm `base-branch-guard` fails.
- [ ] Open the next real release PR (`develop` → `main`) and confirm `base-branch-guard` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)