### PR TITLE
ci: pin third-party actions to commit SHAs so workflow can start

### DIFF
--- a/.github/workflows/tests_and_linters_and_docs_build.yaml
+++ b/.github/workflows/tests_and_linters_and_docs_build.yaml
@@ -60,14 +60,14 @@ jobs:
 
       - name: Pytest coverage comment 💬
         id: coverageComment
-        uses: MishaKav/pytest-coverage-comment@main
+        uses: MishaKav/pytest-coverage-comment@287292879eaaff04116f36d3eb1a670f6e5df1a4 # v1.1.54
         with:
           pytest-xml-coverage-path: ./coverage.xml
           junitxml-path: ./pytest.xml
 
       - name: Create the Badge 🎖️
         if: github.ref == 'refs/heads/main'
-        uses: schneegans/dynamic-badges-action@v1.7.0
+        uses: schneegans/dynamic-badges-action@e9a478b16159b4d31420099ba146cdc50f134483 # v1.7.0
         with:
           auth: ${{ secrets.BOT_ACCESS_TOKEN }}
           gistID: e7c79b17c0a9d47bc826100ef880a16f


### PR DESCRIPTION
## Summary
Every `Tests and Linters and Docs build 🧪` run on a PR or push since 2026-05-19 is finishing in 0s with `startup_failure` ("This run likely failed because of a workflow file issue"). The last successful run was on 2026-04-02 against the same workflow file contents — so it's not the workflow logic, it's GitHub's org-level *allowed-actions* policy refusing to start it.

The workflow uses two unverified third-party actions, both referenced by mutable refs:

- `MishaKav/pytest-coverage-comment@main`
- `schneegans/dynamic-badges-action@v1.7.0`

Pinning them to full commit SHAs satisfies the policy and lets the workflow start. These are the same SHAs already adopted in mlip-jax (instadeepai/mlip-jax#791):

- `MishaKav/pytest-coverage-comment` → `287292879eaaff04116f36d3eb1a670f6e5df1a4` (v1.1.54)
- `schneegans/dynamic-badges-action` → `e9a478b16159b4d31420099ba146cdc50f134483` (v1.7.0)

## Why this matters now
PRs #128 and #129 currently look like they have no test signal at all, because the workflow never enters its first step. Once this merges, those PRs (and any future ones) will pick up real `tests` and `linters` check results — which are also the two required status checks declared on the `Default branch` and `Main release-only` rulesets, so without this fix nothing can actually merge.

## Test plan
- [ ] After merge to `develop`, rebase / re-run CI on PRs #128 and #129 and confirm the `tests`, `linters`, and `docs-build` jobs all start (and presumably pass).
- [ ] Confirm the coverage comment still posts on a normal PR run.
- [ ] Confirm the coverage badge on `main` still updates on the next release merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)