### PR TITLE
feat: add dataset flag for wiggle150 / folmsbee

### DIFF
--- a/src/mlipaudit/benchmarks/conformer_selection/conformer_selection.py
+++ b/src/mlipaudit/benchmarks/conformer_selection/conformer_selection.py
@@ -177,31 +177,45 @@ class ConformerSelectionBenchmark(Benchmark):
         directly. The energy profile is stored in the `model_output` attribute.
         """
         molecule_outputs, num_failed = [], 0
+        all_atoms_list = []
+        structure_atom_idx = []
+        i = 0
         for structure in self._folmsbee_data:
             logger.info("Running energy calculations for %s", structure.molecule_name)
 
-            atoms_list = []
+            idx_list = []
             for conformer_idx in range(len(structure.conformer_coordinates)):
                 atoms = Atoms(
                     symbols=structure.atom_symbols,
                     positions=structure.conformer_coordinates[conformer_idx],
                 )
-                atoms_list.append(atoms)
+                all_atoms_list.append(atoms)
+                idx_list.append(i)
+                i += 1
 
-            predictions = run_inference(
-                atoms_list,
-                self.force_field,
-                batch_size=16,
-            )
+            structure_atom_idx.append(idx_list)
 
-            if None in predictions:
+        predictions_all = run_inference(
+            all_atoms_list,
+            self.force_field,
+            batch_size=16,
+        )
+
+        for i_structure, structure in enumerate(self._folmsbee_data):
+            pred_idx_structure = structure_atom_idx[i_structure]
+            predictions_structure = [predictions_all[j] for j in pred_idx_structure]
+
+            if None in predictions_structure:
                 model_output = ConformerSelectionMoleculeModelOutput(
                     molecule_name=structure.molecule_name, failed=True
                 )
                 num_failed += 1
 
             else:
-                energy_profile_list = [prediction.energy for prediction in predictions]  # type: ignore
+                energy_profile_list = [
+                    prediction.energy  # type: ignore
+                    for prediction in predictions_structure  # type: ignore
+                ]
                 model_output = ConformerSelectionMoleculeModelOutput(
                     molecule_name=structure.molecule_name,
                     predicted_energy_profile=energy_profile_list,

--- a/src/mlipaudit/benchmarks/conformer_selection/conformer_selection.py
+++ b/src/mlipaudit/benchmarks/conformer_selection/conformer_selection.py
@@ -30,6 +30,7 @@ from mlipaudit.utils import run_inference
 logger = logging.getLogger("mlipaudit")
 
 WIGGLE_DATASET_FILENAME = "wiggle150_dataset.json"
+FOLMSBEE_DATASET_FILENAME = "folmsbee_dataset.json"
 NUM_DEV_SYSTEMS = 1
 
 MAE_SCORE_THRESHOLD = 0.5
@@ -167,7 +168,7 @@ class ConformerSelectionBenchmark(Benchmark):
     result_class = ConformerSelectionResult
     model_output_class = ConformerSelectionModelOutput
 
-    required_elements = {"H", "C", "O", "S", "F", "Cl", "N"}
+    required_elements = {"H", "C", "O", "S", "P", "F", "Cl", "Br", "N"}
 
     def run_model(self) -> None:
         """Run a single point energy calculation for each structure.
@@ -176,7 +177,7 @@ class ConformerSelectionBenchmark(Benchmark):
         directly. The energy profile is stored in the `model_output` attribute.
         """
         molecule_outputs, num_failed = [], 0
-        for structure in self._wiggle150_data:
+        for structure in self._folmsbee_data:
             logger.info("Running energy calculations for %s", structure.molecule_name)
 
             atoms_list = []
@@ -229,7 +230,7 @@ class ConformerSelectionBenchmark(Benchmark):
 
         reference_energy_profiles = {
             conformer.molecule_name: np.array(conformer.dft_energy_profile)
-            for conformer in self._wiggle150_data
+            for conformer in self._folmsbee_data
         }
         results = []
 
@@ -312,3 +313,17 @@ class ConformerSelectionBenchmark(Benchmark):
             wiggle150_data = wiggle150_data[:NUM_DEV_SYSTEMS]
 
         return wiggle150_data
+
+    @functools.cached_property
+    def _folmsbee_data(self) -> list[Conformer]:
+        with open(
+            self.data_input_dir / self.name / FOLMSBEE_DATASET_FILENAME,
+            mode="r",
+            encoding="utf-8",
+        ) as f:
+            folmsbee_data = Conformers.validate_json(f.read())
+
+        if self.run_mode == RunMode.DEV:
+            folmsbee_data = folmsbee_data[:NUM_DEV_SYSTEMS]
+
+        return folmsbee_data

--- a/src/mlipaudit/benchmarks/conformer_selection/conformer_selection.py
+++ b/src/mlipaudit/benchmarks/conformer_selection/conformer_selection.py
@@ -14,18 +14,30 @@
 
 import functools
 import logging
+import os
 import statistics
+from typing import Literal, TypeAlias
 
 import numpy as np
 from ase import Atoms, units
+from ase.calculators.calculator import Calculator as ASECalculator
+from mlip.models import ForceField
 from pydantic import BaseModel, Field, NonNegativeFloat, TypeAdapter
 from scipy.stats import spearmanr
 from sklearn.metrics import mean_absolute_error, root_mean_squared_error
 
-from mlipaudit.benchmark import DEFAULT_CHARGE, Benchmark, BenchmarkResult, ModelOutput
+from mlipaudit.benchmark import (
+    DEFAULT_CHARGE,
+    Benchmark,
+    BenchmarkResult,
+    ModelOutput,
+    RunModeAsString,
+)
 from mlipaudit.run_mode import RunMode
 from mlipaudit.scoring import compute_benchmark_score
 from mlipaudit.utils import run_inference
+
+DatasetName: TypeAlias = Literal["wiggle150", "folmsbee"]
 
 logger = logging.getLogger("mlipaudit")
 
@@ -170,6 +182,31 @@ class ConformerSelectionBenchmark(Benchmark):
 
     required_elements = {"H", "C", "O", "S", "P", "F", "Cl", "Br", "N"}
 
+    def __init__(
+        self,
+        force_field: ForceField | ASECalculator,
+        data_input_dir: str | os.PathLike = "./data",
+        run_mode: RunMode | RunModeAsString = RunMode.STANDARD,
+        dataset: DatasetName = "folmsbee",
+    ) -> None:
+        """Initializes the benchmark.
+
+        Extends `Benchmark.__init__` with a `dataset` selector.
+
+        Args:
+            force_field: See `Benchmark.__init__`.
+            data_input_dir: See `Benchmark.__init__`.
+            run_mode: See `Benchmark.__init__`.
+            dataset: Which conformer dataset to run against. One of
+                `"wiggle150"` or `"folmsbee"`. Defaults to `"folmsbee"`.
+        """
+        self.dataset: DatasetName = dataset
+        super().__init__(
+            force_field=force_field,
+            data_input_dir=data_input_dir,
+            run_mode=run_mode,
+        )
+
     def run_model(self) -> None:
         """Run a single point energy calculation for each structure.
 
@@ -180,7 +217,7 @@ class ConformerSelectionBenchmark(Benchmark):
         all_atoms_list = []
         structure_atom_idx = []
         i = 0
-        for structure in self._folmsbee_data:
+        for structure in self._dataset_data:
             logger.info("Running energy calculations for %s", structure.molecule_name)
 
             idx_list = []
@@ -201,7 +238,7 @@ class ConformerSelectionBenchmark(Benchmark):
             batch_size=16,
         )
 
-        for i_structure, structure in enumerate(self._folmsbee_data):
+        for i_structure, structure in enumerate(self._dataset_data):
             pred_idx_structure = structure_atom_idx[i_structure]
             predictions_structure = [predictions_all[j] for j in pred_idx_structure]
 
@@ -244,7 +281,7 @@ class ConformerSelectionBenchmark(Benchmark):
 
         reference_energy_profiles = {
             conformer.molecule_name: np.array(conformer.dft_energy_profile)
-            for conformer in self._folmsbee_data
+            for conformer in self._dataset_data
         }
         results = []
 
@@ -313,6 +350,12 @@ class ConformerSelectionBenchmark(Benchmark):
             avg_rmse=avg_rmse,
             score=score,
         )
+
+    @property
+    def _dataset_data(self) -> list[Conformer]:
+        if self.dataset == "wiggle150":
+            return self._wiggle150_data
+        return self._folmsbee_data
 
     @functools.cached_property
     def _wiggle150_data(self) -> list[Conformer]:

--- a/tests/conformer_selection/test_conformer_selection.py
+++ b/tests/conformer_selection/test_conformer_selection.py
@@ -54,6 +54,7 @@ def conformer_selection_benchmark(
         force_field=mock_force_field,
         data_input_dir=INPUT_DATA_DIR,
         run_mode=run_mode,
+        dataset="wiggle150",
     )
 
 
@@ -83,18 +84,18 @@ def test_full_run_with_mocked_inference(
         is ConformerSelectionMoleculeModelOutput
     )
     assert len(benchmark.model_output.molecules[0].predicted_energy_profile) == len(
-        benchmark._wiggle150_data[0].conformer_coordinates
+        benchmark._dataset_data[0].conformer_coordinates
     )
     result = benchmark.analyze()
 
     assert type(result) is ConformerSelectionResult
-    assert len(result.molecules) == len(benchmark._wiggle150_data)
+    assert len(result.molecules) == len(benchmark._dataset_data)
     assert type(result.molecules[0]) is ConformerSelectionMoleculeResult
     assert len(result.molecules[0].predicted_energy_profile) == len(
-        benchmark._wiggle150_data[0].conformer_coordinates
+        benchmark._dataset_data[0].conformer_coordinates
     )
     assert len(result.molecules[0].reference_energy_profile) == len(
-        benchmark._wiggle150_data[0].dft_energy_profile
+        benchmark._dataset_data[0].dft_energy_profile
     )
     maes = [mol.mae for mol in result.molecules]
     rmses = [mol.rmse for mol in result.molecules]


### PR DESCRIPTION
## Summary
- Add a `dataset: Literal["wiggle150", "folmsbee"] = "folmsbee"` constructor flag on `ConformerSelectionBenchmark`, dispatched through a new `_dataset_data` property so `run_model` and `analyze` consume whichever dataset was selected.
- Update tests to pin the fixture to `dataset="wiggle150"` (the only dataset shipped under `tests/data/`) and read through `_dataset_data`, restoring the wiggle150 assertions that had silently gone stale after the folmsbee migration.
- Drop a stale `call_count == 2` assertion left over from the "run inference only once" refactor — inference now runs in a single batched call regardless of run mode.

## Test plan
- [x] `pytest tests/conformer_selection/test_conformer_selection.py` — 10/10 passing locally
- [ ] CI green on this branch

## Notes
- Branch is rebased onto `origin/develop`.
- The flag is intentionally **not** wired into the `mlipaudit benchmark` CLI yet — only reachable via direct `ConformerSelectionBenchmark(..., dataset=...)` instantiation. Happy to expose it via CLI in a follow-up if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)