### PR TITLE
perf: lazy-load heavy deps to speed up CLI startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Speed up CLI startup (e.g. `mlipaudit -h`) from ~6s to ~1s by importing the
+  heavy `mlip`/JAX/JAX-MD/scikit-learn dependencies lazily, only when a benchmark
+  is actually run, rather than at import time of the benchmark modules.
+
 ## Release 0.1.3
 
 - Populate `atoms.info["charge"]` and `atoms.info["spin"]` on every benchmark's

--- a/src/mlipaudit/benchmark.py
+++ b/src/mlipaudit/benchmark.py
@@ -12,20 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import os
 import zipfile
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, Literal, TypeAlias
+from typing import TYPE_CHECKING, Any, Literal, TypeAlias
 
 from ase import Atom
 from ase.calculators.calculator import Calculator as ASECalculator
 from huggingface_hub import hf_hub_download
-from mlip.models import ForceField
 from pydantic import BaseModel, Field
 
 from mlipaudit.exceptions import ChemicalElementsMissingError
 from mlipaudit.run_mode import RunMode
+
+if TYPE_CHECKING:
+    # `mlip.models` pulls in the full model/JAX stack (~2s); importing it lazily
+    # keeps benchmark classes cheap to import (e.g. for `mlipaudit -h`).
+    from mlip.models import ForceField
 
 RunModeAsString: TypeAlias = Literal["dev", "fast", "standard"]
 
@@ -138,6 +144,8 @@ class Benchmark(ABC):
             self.run_mode = RunMode(run_mode)
 
         self.force_field = force_field
+
+        from mlip.models import ForceField  # noqa: PLC0415
 
         if not (
             isinstance(self.force_field, ForceField)

--- a/src/mlipaudit/benchmarks/conformer_selection/conformer_selection.py
+++ b/src/mlipaudit/benchmarks/conformer_selection/conformer_selection.py
@@ -12,19 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import functools
 import logging
 import os
 import statistics
-from typing import Literal, TypeAlias
+from typing import TYPE_CHECKING, Literal, TypeAlias
 
 import numpy as np
 from ase import Atoms, units
 from ase.calculators.calculator import Calculator as ASECalculator
-from mlip.models import ForceField
 from pydantic import BaseModel, Field, NonNegativeFloat, TypeAdapter
 from scipy.stats import spearmanr
-from sklearn.metrics import mean_absolute_error, root_mean_squared_error
 
 from mlipaudit.benchmark import (
     DEFAULT_CHARGE,
@@ -37,6 +37,10 @@ from mlipaudit.benchmark import (
 from mlipaudit.run_mode import RunMode
 from mlipaudit.scoring import compute_benchmark_score
 from mlipaudit.utils import run_inference
+
+if TYPE_CHECKING:
+    # `mlip.models` pulls in the heavy model/JAX stack; only needed for typing here.
+    from mlip.models import ForceField
 
 DatasetName: TypeAlias = Literal["wiggle150", "folmsbee"]
 
@@ -279,6 +283,11 @@ class ConformerSelectionBenchmark(Benchmark):
         Raises:
             RuntimeError: If called before `run_model()`.
         """
+        from sklearn.metrics import (  # noqa: PLC0415
+            mean_absolute_error,
+            root_mean_squared_error,
+        )
+
         if self.model_output is None:
             raise RuntimeError("Must call run_model() first.")
 

--- a/src/mlipaudit/benchmarks/dihedral_scan/dihedral_scan.py
+++ b/src/mlipaudit/benchmarks/dihedral_scan/dihedral_scan.py
@@ -21,7 +21,6 @@ import numpy as np
 from ase import Atoms, units
 from pydantic import BaseModel, Field, NonNegativeFloat, TypeAdapter
 from scipy.stats import pearsonr
-from sklearn.metrics import mean_absolute_error, root_mean_squared_error
 
 from mlipaudit.benchmark import (
     DEFAULT_CHARGE,
@@ -331,6 +330,11 @@ class DihedralScanBenchmark(Benchmark):
         ref_energy_profile: np.ndarray,
         predicted_energy_profile: np.ndarray,
     ) -> tuple[float, float, float, float, float]:
+        from sklearn.metrics import (  # noqa: PLC0415
+            mean_absolute_error,
+            root_mean_squared_error,
+        )
+
         mae = mean_absolute_error(ref_energy_profile, predicted_energy_profile)
         rmse = root_mean_squared_error(ref_energy_profile, predicted_energy_profile)
 

--- a/src/mlipaudit/benchmarks/nudged_elastic_band/nudged_elastic_band.py
+++ b/src/mlipaudit/benchmarks/nudged_elastic_band/nudged_elastic_band.py
@@ -12,14 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import functools
 import logging
+from typing import TYPE_CHECKING
 
 import numpy as np
 from ase import Atoms
 from mlip.simulation import SimulationState
-from mlip.simulation.ase import ASESimulationEngine
-from mlip.simulation.configs import ASESimulationConfig
 from pydantic import BaseModel, ConfigDict, TypeAdapter
 
 from mlipaudit.benchmark import (
@@ -29,11 +30,15 @@ from mlipaudit.benchmark import (
     BenchmarkResult,
     ModelOutput,
 )
-from mlipaudit.benchmarks.nudged_elastic_band.engine import (
-    NEBSimulationConfig,
-    NEBSimulationEngine,
-)
 from mlipaudit.run_mode import RunMode
+
+if TYPE_CHECKING:
+    # Used only in type annotations. The matching runtime imports happen lazily inside
+    # the run methods so that importing this benchmark module (e.g. for the CLI
+    # benchmark listing) does not pull in the heavy mlip/JAX-MD stack.
+    from mlip.simulation.configs import ASESimulationConfig
+
+    from mlipaudit.benchmarks.nudged_elastic_band.engine import NEBSimulationConfig
 
 logger = logging.getLogger("mlipaudit")
 
@@ -230,6 +235,13 @@ class NudgedElasticBandBenchmark(Benchmark):
 
     def run_model(self) -> None:
         """Run the NEB calculation."""
+        # Imported lazily (pulls in the heavy mlip/JAX-MD stack via the NEB engine).
+        from mlip.simulation.configs import ASESimulationConfig  # noqa: PLC0415
+
+        from mlipaudit.benchmarks.nudged_elastic_band.engine import (  # noqa: PLC0415
+            NEBSimulationConfig,
+        )
+
         self.model_output = NEBModelOutput(
             simulation_states=[],
         )
@@ -364,6 +376,8 @@ class NudgedElasticBandBenchmark(Benchmark):
             atoms_initial_em: The initial atoms after energy minimization.
             atoms_final_em: The final atoms after energy minimization.
         """
+        from mlip.simulation.ase import ASESimulationEngine  # noqa: PLC0415
+
         em_engine_initial = ASESimulationEngine(initial_atoms, ff, em_config)
         em_engine_initial.run()
 
@@ -398,6 +412,10 @@ class NudgedElasticBandBenchmark(Benchmark):
         Returns:
             neb_engine_climb: The nudged elastic band engine with climbing image method.
         """
+        from mlipaudit.benchmarks.nudged_elastic_band.engine import (  # noqa: PLC0415
+            NEBSimulationEngine,
+        )
+
         neb_engine = NEBSimulationEngine(
             initial_atoms, final_atoms, ff, neb_config, transition_state=ts_atoms
         )

--- a/src/mlipaudit/benchmarks/water_radial_distribution/water_radial_distribution.py
+++ b/src/mlipaudit/benchmarks/water_radial_distribution/water_radial_distribution.py
@@ -22,7 +22,6 @@ from ase import Atoms, units
 from ase.io import read as ase_read
 from mlip.simulation import SimulationState
 from pydantic import ConfigDict, NonNegativeFloat
-from sklearn.metrics import mean_absolute_error, root_mean_squared_error
 
 from mlipaudit.benchmark import (
     DEFAULT_CHARGE,
@@ -177,6 +176,11 @@ class WaterRadialDistributionBenchmark(Benchmark):
         Raises:
             RuntimeError: If called before `run_model()`.
         """
+        from sklearn.metrics import (  # noqa: PLC0415
+            mean_absolute_error,
+            root_mean_squared_error,
+        )
+
         if self.model_output is None:
             raise RuntimeError("Must call run_model() first.")
 

--- a/src/mlipaudit/main.py
+++ b/src/mlipaudit/main.py
@@ -17,13 +17,11 @@ import textwrap
 from argparse import ArgumentParser, Namespace, RawDescriptionHelpFormatter
 
 import mlipaudit
-from mlipaudit.app import launch_app
 from mlipaudit.benchmark import Benchmark
 from mlipaudit.benchmarks import (
     BENCHMARK_NAMES,
     BENCHMARKS,
 )
-from mlipaudit.benchmarks_cli import run_benchmarks
 from mlipaudit.run_mode import RunMode
 
 logger = logging.getLogger("mlipaudit")
@@ -202,6 +200,8 @@ def main():
         mlip_logger.setLevel(logging.WARNING)
 
     if args.command == "benchmark":
+        from mlipaudit.benchmarks_cli import run_benchmarks  # noqa: PLC0415
+
         benchmarks_to_run = _get_benchmarks_to_run(args)
         run_benchmarks(
             model_paths=args.models,
@@ -213,6 +213,8 @@ def main():
             log_timings=args.log_timings,
         )
     elif args.command == "gui":
+        from mlipaudit.app import launch_app  # noqa: PLC0415
+
         launch_app(args.results_dir, args.is_public)
     else:
         parser.print_help()

--- a/src/mlipaudit/utils/__init__.py
+++ b/src/mlipaudit/utils/__init__.py
@@ -13,12 +13,22 @@
 # limitations under the License.
 
 from mlipaudit.utils.inference import run_inference
-from mlipaudit.utils.simulation import (
-    ASESimulationEngineWithCalculator,
-    run_simulation,
-)
+from mlipaudit.utils.simulation import run_simulation
 from mlipaudit.utils.trajectory_helpers import (
     create_ase_trajectory_from_simulation_state,
     create_mdtraj_trajectory_from_simulation_state,
 )
 from mlipaudit.utils.unallowed_elements import skip_unallowed_elements
+
+
+def __getattr__(name: str):
+    # `ASESimulationEngineWithCalculator` is built lazily (it derives from a heavy
+    # mlip base class). Re-export it via PEP 562 so importing `mlipaudit.utils` does
+    # not pull in the JAX-MD stack unless the class is actually used.
+    if name == "ASESimulationEngineWithCalculator":
+        from mlipaudit.utils._ase_engine import (  # noqa: PLC0415
+            ASESimulationEngineWithCalculator,
+        )
+
+        return ASESimulationEngineWithCalculator
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/mlipaudit/utils/_ase_engine.py
+++ b/src/mlipaudit/utils/_ase_engine.py
@@ -1,0 +1,79 @@
+# Copyright 2025 InstaDeep Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Custom ASE simulation engine.
+
+This module is kept separate from :mod:`mlipaudit.utils.simulation` because
+importing it pulls in the heavy ``mlip.simulation.ase`` (and therefore JAX-MD)
+stack. It is only imported lazily, when a simulation is actually run, so that
+merely importing the benchmark modules (e.g. for the CLI) stays fast.
+"""
+
+import logging
+from typing import Callable
+
+import ase
+from ase.calculators.calculator import Calculator as ASECalculator
+from mlip.simulation import SimulationState
+from mlip.simulation.ase import ASESimulationEngine
+from mlip.simulation.configs import ASESimulationConfig
+from mlip.simulation.enums import SimulationType
+from mlip.simulation.temperature_scheduling import get_temperature_schedule
+
+logger = logging.getLogger("mlipaudit")
+
+
+class ASESimulationEngineWithCalculator(ASESimulationEngine):
+    """Class derived from mlip's ASE simulation engine but allowing for a passed
+    ASE calculator object.
+    """
+
+    def __init__(
+        self,
+        atoms: ase.Atoms,
+        ase_calculator: ASECalculator,
+        config: ASESimulationConfig,
+    ) -> None:
+        """Overridden constructor that takes in an ASE calculator instead of an
+        mlip force field class.
+
+        Args:
+            atoms: The ASE atoms.
+            ase_calculator: The ASE calculator to use in the simulation.
+            config: The simulation config.
+        """
+        self.state = SimulationState()
+        self.loggers: list[Callable[[SimulationState], None]] = []
+
+        logger.debug("Initialization of simulation begins...")
+        self._config = config
+        self.atoms = atoms
+        self.atoms.center()
+        positions = atoms.get_positions()
+        self._num_atoms = positions.shape[0]
+        self.state.atomic_numbers = atoms.numbers
+
+        self._init_box()
+
+        self.is_md_simulation = self._config.simulation_type == SimulationType.MD
+        self.is_npt_simulation = (
+            self.is_md_simulation and self._config.md_integrator.ensemble == "npt"
+        )
+
+        self.model_calculator = ase_calculator
+
+        self._temperature_schedule = get_temperature_schedule(
+            self._config.temperature_schedule_config, self._config.num_steps
+        )
+
+        logger.debug("Initialization of simulation completed.")

--- a/src/mlipaudit/utils/inference.py
+++ b/src/mlipaudit/utils/inference.py
@@ -11,13 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
 import logging
+from typing import TYPE_CHECKING
 
 import ase
 from ase.calculators.calculator import Calculator as ASECalculator
-from mlip.inference import run_batched_inference
-from mlip.models import ForceField
-from mlip.typing import Prediction
+
+if TYPE_CHECKING:
+    # These pull in the heavy mlip/JAX stack; imported lazily inside `run_inference`
+    # so that merely importing this module stays cheap.
+    from mlip.models import ForceField
+    from mlip.typing import Prediction
 
 logger = logging.getLogger("mlipaudit")
 
@@ -45,6 +51,12 @@ def run_inference(
     Raises:
         ValueError: If force field type is not compatible.
     """
+    # Imported lazily to keep importing this module cheap (these pull in the heavy
+    # mlip/JAX stack, only needed when inference is actually run).
+    from mlip.inference import run_batched_inference  # noqa: PLC0415
+    from mlip.models import ForceField  # noqa: PLC0415
+    from mlip.typing import Prediction  # noqa: PLC0415
+
     if isinstance(force_field, ForceField):
         try:
             predictions = run_batched_inference(

--- a/src/mlipaudit/utils/simulation.py
+++ b/src/mlipaudit/utils/simulation.py
@@ -12,69 +12,42 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import logging
 from copy import deepcopy
-from typing import Callable
+from typing import TYPE_CHECKING
 
 import ase
 from ase.calculators.calculator import Calculator as ASECalculator
-from mlip.models import ForceField
 from mlip.simulation import SimulationState
-from mlip.simulation.ase import ASESimulationEngine
-from mlip.simulation.configs import ASESimulationConfig
-from mlip.simulation.enums import SimulationType
-from mlip.simulation.jax_md import JaxMDSimulationEngine
-from mlip.simulation.temperature_scheduling import get_temperature_schedule
+
+if TYPE_CHECKING:
+    # These pull in the heavy mlip/JAX-MD stack (~1.5s). They are imported lazily
+    # below so that importing this module (e.g. via `mlipaudit.utils`) stays cheap.
+    from mlip.models import ForceField
+    from mlip.simulation.ase import ASESimulationEngine
+    from mlip.simulation.jax_md import JaxMDSimulationEngine
+
+    from mlipaudit.utils._ase_engine import ASESimulationEngineWithCalculator
 
 REUSABLE_BIOMOLECULES_OUTPUTS_ID = ("sampling", "folding_stability")
 
 logger = logging.getLogger("mlipaudit")
 
 
-class ASESimulationEngineWithCalculator(ASESimulationEngine):
-    """Class derived from mlip's ASE simulation engine but allowing for a passed
-    ASE calculator object.
-    """
-
-    def __init__(
-        self,
-        atoms: ase.Atoms,
-        ase_calculator: ASECalculator,
-        config: ASESimulationConfig,
-    ) -> None:
-        """Overridden constructor that takes in an ASE calculator instead of an
-        mlip force field class.
-
-        Args:
-            atoms: The ASE atoms.
-            ase_calculator: The ASE calculator to use in the simulation.
-            config: The simulation config.
-        """
-        self.state = SimulationState()
-        self.loggers: list[Callable[[SimulationState], None]] = []
-
-        logger.debug("Initialization of simulation begins...")
-        self._config = config
-        self.atoms = atoms
-        self.atoms.center()
-        positions = atoms.get_positions()
-        self._num_atoms = positions.shape[0]
-        self.state.atomic_numbers = atoms.numbers
-
-        self._init_box()
-
-        self.is_md_simulation = self._config.simulation_type == SimulationType.MD
-        self.is_npt_simulation = (
-            self.is_md_simulation and self._config.md_integrator.ensemble == "npt"
+def __getattr__(name: str):
+    # PEP 562 module-level attribute access. Keeps the historical
+    # `mlipaudit.utils.simulation.ASESimulationEngineWithCalculator` import path
+    # working without pulling in the heavy mlip stack at module import time (the
+    # class lives in `_ase_engine`, whose import is expensive).
+    if name == "ASESimulationEngineWithCalculator":
+        from mlipaudit.utils._ase_engine import (  # noqa: PLC0415
+            ASESimulationEngineWithCalculator,
         )
 
-        self.model_calculator = ase_calculator
-
-        self._temperature_schedule = get_temperature_schedule(
-            self._config.temperature_schedule_config, self._config.num_steps
-        )
-
-        logger.debug("Initialization of simulation completed.")
+        return ASESimulationEngineWithCalculator
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def get_simulation_engine(
@@ -101,6 +74,12 @@ def get_simulation_engine(
     Raises:
         ValueError: If force field type is not compatible.
     """
+    # Imported lazily: these pull in the heavy mlip/JAX-MD stack, which we only want
+    # to pay for when a simulation is actually run (not at import time).
+    from mlip.models import ForceField  # noqa: PLC0415
+    from mlip.simulation.ase import ASESimulationEngine  # noqa: PLC0415
+    from mlip.simulation.jax_md import JaxMDSimulationEngine  # noqa: PLC0415
+
     # Case 1: MD simulations with ForceField objects -> use JAX-MD
     if (
         isinstance(force_field, ForceField)
@@ -134,6 +113,10 @@ def get_simulation_engine(
             "Running ASE-based simulation for a maximum of %d steps.",
             sim_config.num_steps,
         )
+        from mlipaudit.utils._ase_engine import (  # noqa: PLC0415
+            ASESimulationEngineWithCalculator,
+        )
+
         return ASESimulationEngineWithCalculator(atoms, force_field, sim_config)
 
     raise ValueError(

--- a/src/mlipaudit/utils/stability.py
+++ b/src/mlipaudit/utils/stability.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import numpy as np
-from jax import numpy as jnp
 from mlip.simulation import SimulationState
 from scipy.spatial.distance import pdist, squareform
 
@@ -90,6 +89,10 @@ def find_explosion_frame(simulation_state: SimulationState, temperature: float) 
     """
     if simulation_state.temperature is None:
         raise ValueError("Simulation state does not contain temperature information.")
+
+    # Imported lazily: bare `import jax` is ~0.5s and only needed when analysing a
+    # simulation trajectory, not at module import time.
+    from jax import numpy as jnp  # noqa: PLC0415
 
     temperatures = simulation_state.temperature
     threshold = temperature + TEMPERATURE_THRESHOLD

--- a/src/mlipaudit/utils/unallowed_elements.py
+++ b/src/mlipaudit/utils/unallowed_elements.py
@@ -12,8 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from ase.data import chemical_symbols
-from mlip.models import ForceField
+
+if TYPE_CHECKING:
+    # `mlip.models` pulls in the heavy model/JAX stack; only needed for typing here.
+    from mlip.models import ForceField
 
 
 def skip_unallowed_elements(

--- a/tests/bond_length_distribution/test_bond_length_distribution.py
+++ b/tests/bond_length_distribution/test_bond_length_distribution.py
@@ -68,7 +68,7 @@ def test_full_run_with_mocked_engine(
     benchmark = bond_length_distribution_benchmark
     mock_engine = mock_jaxmd_simulation_engine()
     with patch(
-        "mlipaudit.utils.simulation.JaxMDSimulationEngine",
+        "mlip.simulation.jax_md.JaxMDSimulationEngine",
         return_value=mock_engine,
     ) as mock_engine_class:
         benchmark.run_model()

--- a/tests/conformer_selection/test_conformer_selection.py
+++ b/tests/conformer_selection/test_conformer_selection.py
@@ -75,7 +75,7 @@ def test_full_run_with_mocked_inference(
     benchmark = conformer_selection_benchmark
 
     _mocked_batched_inference = mocker.patch(
-        "mlipaudit.utils.inference.run_batched_inference",
+        "mlip.inference.run_batched_inference",
         side_effect=mocked_batched_inference,
     )
 

--- a/tests/dihedral_scan/test_dihederal_scan.py
+++ b/tests/dihedral_scan/test_dihederal_scan.py
@@ -59,7 +59,7 @@ def test_full_run_with_mocked_inference(
     benchmark = dihedral_scan_benchmark
 
     _mocked_batched_inference = mocker.patch(
-        "mlipaudit.utils.inference.run_batched_inference",
+        "mlip.inference.run_batched_inference",
         side_effect=mocked_batched_inference,
     )
 

--- a/tests/folding_stability/test_folding_stability.py
+++ b/tests/folding_stability/test_folding_stability.py
@@ -96,7 +96,7 @@ def test_full_run_with_mocked_simulation_with_static_and_random_trajectory(
     )
 
     with patch(
-        "mlipaudit.utils.simulation.JaxMDSimulationEngine",
+        "mlip.simulation.jax_md.JaxMDSimulationEngine",
         return_value=mock_engine,
     ) as mock_engine_class:
         if benchmark.run_mode == RunMode.DEV:  # Case 1

--- a/tests/noncovalent_interactions/test_noncovalent_interactions.py
+++ b/tests/noncovalent_interactions/test_noncovalent_interactions.py
@@ -64,7 +64,7 @@ def test_full_run_with_mocked_inference(
     benchmark.force_field.allowed_atomic_numbers = list(range(1, 92))
 
     _mocked_batched_inference = mocker.patch(
-        "mlipaudit.utils.inference.run_batched_inference",
+        "mlip.inference.run_batched_inference",
         side_effect=mocked_batched_inference,
     )
 

--- a/tests/nudged_elastic_band/test_nudged_elastic_band.py
+++ b/tests/nudged_elastic_band/test_nudged_elastic_band.py
@@ -57,11 +57,11 @@ def test_nudged_elastic_band_benchmark_can_be_run(
     mock_neb_4 = mock_neb_simulation_engine()
 
     with patch(
-        "mlipaudit.benchmarks.nudged_elastic_band.nudged_elastic_band.ASESimulationEngine",
+        "mlip.simulation.ase.ASESimulationEngine",
         side_effect=[mock_ase_1, mock_ase_2, mock_ase_3, mock_ase_4],
     ) as mock_ase_engine_class:
         with patch(
-            "mlipaudit.benchmarks.nudged_elastic_band.nudged_elastic_band.NEBSimulationEngine",
+            "mlipaudit.benchmarks.nudged_elastic_band.engine.NEBSimulationEngine",
             side_effect=[mock_neb_1, mock_neb_2, mock_neb_3, mock_neb_4],
         ) as mock_neb_engine_class:
             nudged_elastic_band_benchmark.run_model()

--- a/tests/reactivity/test_reactivity.py
+++ b/tests/reactivity/test_reactivity.py
@@ -58,7 +58,7 @@ def test_full_run_with_mocked_inference(
 ):
     """Integration test using the modular fixture for fast dev run."""
     _mocked_batched_inference = mocker.patch(
-        "mlipaudit.utils.inference.run_batched_inference",
+        "mlip.inference.run_batched_inference",
         side_effect=mocked_batched_inference,
     )
 

--- a/tests/reference_geometry_stability/test_reference_geometry_stability.py
+++ b/tests/reference_geometry_stability/test_reference_geometry_stability.py
@@ -79,7 +79,7 @@ def test_full_run_with_mocked_engine(
     benchmark = ref_geometry_stability_benchmark
     mock_engine = mock_ase_simulation_engine()
     with patch(
-        "mlipaudit.utils.simulation.ASESimulationEngine",
+        "mlip.simulation.ase.ASESimulationEngine",
         return_value=mock_engine,
     ) as mock_engine_class:
         benchmark.run_model()

--- a/tests/ring_planarity/test_ring_planarity.py
+++ b/tests/ring_planarity/test_ring_planarity.py
@@ -107,7 +107,7 @@ def test_full_run_with_mocked_engine(
     benchmark = ring_planarity_benchmark
     mock_engine = mock_jaxmd_simulation_engine()
     with patch(
-        "mlipaudit.utils.simulation.JaxMDSimulationEngine",
+        "mlip.simulation.jax_md.JaxMDSimulationEngine",
         return_value=mock_engine,
     ) as mock_engine_class:
         benchmark.run_model()

--- a/tests/sampling/test_sampling.py
+++ b/tests/sampling/test_sampling.py
@@ -262,7 +262,7 @@ def test_sampling_benchmark_full_run_with_mock_engine(
     )
 
     with patch(
-        "mlipaudit.utils.simulation.JaxMDSimulationEngine",
+        "mlip.simulation.jax_md.JaxMDSimulationEngine",
         return_value=mock_engine,
     ) as mock_engine_class:
         if benchmark.run_mode == RunMode.DEV:

--- a/tests/solvent_radial_distribution/test_solvent_radial_distribution.py
+++ b/tests/solvent_radial_distribution/test_solvent_radial_distribution.py
@@ -62,7 +62,7 @@ def test_full_run_with_mocked_engine(
     benchmark = solvent_radial_distribution_benchmark
     mock_engine = mock_jaxmd_simulation_engine()
     with patch(
-        "mlipaudit.utils.simulation.JaxMDSimulationEngine",
+        "mlip.simulation.jax_md.JaxMDSimulationEngine",
         return_value=mock_engine,
     ) as mock_engine_class:
         benchmark.run_model()

--- a/tests/stability/test_stability.py
+++ b/tests/stability/test_stability.py
@@ -154,7 +154,7 @@ def test_full_run_with_mocked_engine(stability_benchmark, mock_jaxmd_simulation_
     benchmark = stability_benchmark
     mock_engine = mock_jaxmd_simulation_engine()
     with patch(
-        "mlipaudit.utils.simulation.JaxMDSimulationEngine",
+        "mlip.simulation.jax_md.JaxMDSimulationEngine",
         return_value=mock_engine,
     ) as mock_engine_class:
         benchmark.run_model()

--- a/tests/tautomers/test_tautomers.py
+++ b/tests/tautomers/test_tautomers.py
@@ -61,7 +61,7 @@ def test_full_run_with_mocked_inference(
     benchmark = tautomers_benchmark
 
     _mocked_batched_inference = mocker.patch(
-        "mlipaudit.utils.inference.run_batched_inference",
+        "mlip.inference.run_batched_inference",
         side_effect=mocked_batched_inference,
     )
 

--- a/tests/water_radial_distribution/test_water_radial_distribution.py
+++ b/tests/water_radial_distribution/test_water_radial_distribution.py
@@ -64,7 +64,7 @@ def test_full_run_with_mocked_engine(
     benchmark = water_radial_distribution_benchmark
     mock_engine = mock_jaxmd_simulation_engine()
     with patch(
-        "mlipaudit.utils.simulation.JaxMDSimulationEngine",
+        "mlip.simulation.jax_md.JaxMDSimulationEngine",
         return_value=mock_engine,
     ) as mock_engine_class:
         benchmark.run_model()


### PR DESCRIPTION
## Why

`mlipaudit -h` takes ~6s. The cost is entirely import time, not argument parsing: `main.py` imports `mlipaudit.benchmarks` (needed to build the `--benchmarks` choices for the parser), and that transitively pulls in the full ML/plotting stack just to print a help string:

| Chain | ~cost | pulled in via |
|---|---|---|
| `mlip.models` (ESEN network, flax) | ~2.2s | `Benchmark` base / `ForceField` type hints |
| `mlip.simulation.ase` → `jax_md.rigid_body` | ~1.5s | `utils.simulation` engine |
| `sklearn.metrics` | ~0.7s | conformer / dihedral / water benchmarks |
| bare `import jax` | ~0.5s | `utils.stability` |

None of this is needed to list benchmarks or print help — only to actually *run* a benchmark.

## What

Defer the heavy imports to call time:

- **`benchmark.py`, `utils/{inference,simulation,stability,unallowed_elements}.py`**: move `mlip.models` / `mlip.simulation.ase` (JAX-MD) / `jax` / `sklearn` imports into the functions that use them; type-only references go under `TYPE_CHECKING` with `from __future__ import annotations`.
- **`utils/_ase_engine.py`** (new): `ASESimulationEngineWithCalculator` subclasses the heavy `ASESimulationEngine`, so a class definition can't be lazy. Moved it to its own module imported lazily when a simulation runs; the historical `mlipaudit.utils[.simulation].ASESimulationEngineWithCalculator` paths still work via module-level `__getattr__`.
- **`nudged_elastic_band`, `conformer_selection`, `dihedral_scan`, `water_radial_distribution`**: defer their `mlip` / `sklearn` imports into the run/analyze methods.
- **`main.py`**: import `launch_app` / `run_benchmarks` inside their command branches.

### Tests

The benchmark tests patched the now-lazy symbols at the *use-site* module (e.g. `mlipaudit.utils.simulation.JaxMDSimulationEngine`), which no longer exists there. Updated them to patch at the **definition site** (e.g. `mlip.simulation.jax_md.JaxMDSimulationEngine`) — the lazy `from ... import` picks the patch up at call time, and `create_autospec` in `conftest` (which binds the real class at import) is unaffected.

## Result

- `mlipaudit -h`: **~5.6s → ~0.9s**
- `import mlipaudit.benchmarks`: **~5.0s → ~1.1s**
- All 128 tests pass; ruff / ruff-format / mypy clean.

## Notes

- `mlipaudit benchmark -h` has a pre-existing argparse `AssertionError` (unrelated to this change; reproduces on `main`) and is left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)