### PR TITLE
fix: score partial NEB failures 

### DIFF
--- a/src/mlipaudit/benchmarks/nudged_elastic_band/nudged_elastic_band.py
+++ b/src/mlipaudit/benchmarks/nudged_elastic_band/nudged_elastic_band.py
@@ -323,6 +323,7 @@ class NudgedElasticBandBenchmark(Benchmark):
                 reaction_results.append(
                     NEBReactionResult(reaction_id=self._reaction_ids[i], failed=True)
                 )
+                continue
 
             neb_final_force = np.sqrt((simulation_state.forces**2).sum(axis=1).max())
             if neb_final_force < FINAL_CONVERGENCE_THRESHOLD:

--- a/src/mlipaudit/benchmarks/nudged_elastic_band/nudged_elastic_band.py
+++ b/src/mlipaudit/benchmarks/nudged_elastic_band/nudged_elastic_band.py
@@ -313,7 +313,15 @@ class NudgedElasticBandBenchmark(Benchmark):
             simulation_state is None
             for simulation_state in self.model_output.simulation_states
         ):
-            return NEBResult(failed=True, score=0.0)
+            return NEBResult(
+                reaction_results=[
+                    NEBReactionResult(reaction_id=reaction_id, failed=True)
+                    for reaction_id in self._reaction_ids
+                ],
+                convergence_rate=0.0,
+                failed=True,
+                score=0.0,
+            )
 
         n_converged = 0
         n_total = len(self.model_output.simulation_states)

--- a/tests/nudged_elastic_band/test_nudged_elastic_band.py
+++ b/tests/nudged_elastic_band/test_nudged_elastic_band.py
@@ -17,8 +17,10 @@ from unittest.mock import patch
 
 import numpy as np
 import pytest
+from mlip.simulation import SimulationState
 
 from mlipaudit.benchmarks.nudged_elastic_band.nudged_elastic_band import (
+    NEBModelOutput,
     NudgedElasticBandBenchmark,
 )
 from mlipaudit.run_mode import RunMode
@@ -86,3 +88,43 @@ def test_nudged_elastic_band_benchmark_can_be_run(
             result = nudged_elastic_band_benchmark.analyze()
             assert result.convergence_rate == pytest.approx(0.0)
             assert result.score == pytest.approx(0.0)
+
+
+def test_analyze_scores_partial_failure_without_crashing(
+    nudged_elastic_band_benchmark,
+):
+    """Regression test: a mix of failed (None) and valid simulation states must
+    not crash analyze(). The failed reaction should be counted as failed and
+    included in the convergence-rate denominator, while the valid reaction is
+    scored normally. Each reaction must yield exactly one result (no double
+    append for the failed reaction).
+    """
+    converged_state = SimulationState(
+        atomic_numbers=np.array([0, 1]),
+        positions=np.random.rand(10, 2, 3),
+        forces=np.zeros((10, 2, 3)),
+        temperature=np.random.rand(10),
+    )
+
+    nudged_elastic_band_benchmark.model_output = NEBModelOutput(
+        simulation_states=[converged_state, None],
+    )
+    # _reaction_ids is a cached_property; set it directly to avoid reading data.
+    nudged_elastic_band_benchmark._reaction_ids = ["rxn_ok", "rxn_failed"]
+
+    result = nudged_elastic_band_benchmark.analyze()
+
+    # analyze() must not fail overall for a partial failure.
+    assert result.failed is False
+    # Exactly one result per reaction (no double append for the None reaction).
+    assert len(result.reaction_results) == 2
+
+    results_by_id = {r.reaction_id: r for r in result.reaction_results}
+    assert results_by_id["rxn_failed"].failed is True
+    assert results_by_id["rxn_failed"].converged is None
+    assert results_by_id["rxn_ok"].failed is False
+    assert results_by_id["rxn_ok"].converged is True
+
+    # 1 converged of 2 total reactions (failed reaction lowers the rate).
+    assert result.convergence_rate == pytest.approx(0.5)
+    assert result.score == pytest.approx(0.5)

--- a/tests/nudged_elastic_band/test_nudged_elastic_band.py
+++ b/tests/nudged_elastic_band/test_nudged_elastic_band.py
@@ -128,3 +128,25 @@ def test_analyze_scores_partial_failure_without_crashing(
     # 1 converged of 2 total reactions (failed reaction lowers the rate).
     assert result.convergence_rate == pytest.approx(0.5)
     assert result.score == pytest.approx(0.5)
+
+
+def test_analyze_scores_total_failure_without_crashing(
+    nudged_elastic_band_benchmark,
+):
+    """Regression test: when EVERY reaction fails (all simulation states None),
+    analyze() must return a failed NEBResult with score 0.0 and one failed
+    reaction result per reaction, instead of raising a pydantic ValidationError
+    for the missing required ``reaction_results`` field.
+    """
+    nudged_elastic_band_benchmark.model_output = NEBModelOutput(
+        simulation_states=[None, None],
+    )
+    nudged_elastic_band_benchmark._reaction_ids = ["rxn_a", "rxn_b"]
+
+    result = nudged_elastic_band_benchmark.analyze()
+
+    assert result.failed is True
+    assert result.score == pytest.approx(0.0)
+    assert result.convergence_rate == pytest.approx(0.0)
+    assert len(result.reaction_results) == 2
+    assert all(r.failed is True for r in result.reaction_results)


### PR DESCRIPTION
## Problem

`NudgedElasticBandBenchmark.analyze()` crashes with an `AttributeError` when *some* (but not all) NEB reactions fail. A failed reaction leaves its `simulation_state` as `None` (e.g. an ASE "Constraints in image 1 affect the interpolation results" error during interpolation). The per-reaction loop appends a `failed=True` result for a `None` state but then falls through to `np.sqrt((simulation_state.forces**2)...)`, dereferencing `None.forces`.

The existing guard only returns early when *all* reactions are `None`. So a single failed reaction raises out of `analyze()` and the entire benchmark produces **no NEB score at all**, instead of scoring that reaction as failed and the rest normally.

**Failure mode:** partial reaction failure → `AttributeError` → whole benchmark analysis crashes. Observed in practice on a model that failed one reaction while succeeding on the others — the whole NEB benchmark was lost.

## Fix

Add `continue` after appending the `failed=True` result for a `None` simulation state. Each reaction now contributes exactly one result (this also removes a latent double-append that the old fall-through would have caused), and failed reactions are counted in the `n_converged / n_total` denominator, correctly lowering the convergence rate rather than crashing.

## Test

Added `test_analyze_scores_partial_failure_without_crashing`: constructs an `NEBModelOutput` mixing a valid (converged) `SimulationState` with a `None`, and asserts `analyze()` returns without raising, marks the `None` reaction as failed, yields exactly one result per reaction, and reports `convergence_rate == score == 0.5`. The test fails on `develop` (reproduces the `AttributeError`) and passes with the fix.
