### PR TITLE
fix: adapt ASE engine box setup to mlip 0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   MD simulations across a set of gas-phase and solvated systems and scores how well a
   model conserves the total energy, quantified by the drift of the total energy over
   the trajectory.
+- Require `mlip>=0.2.3` and adapt `ASESimulationEngineWithCalculator` to its refactor
+  of `ASESimulationEngine._init_box` into the `resolve_atoms_cell` helper.
 
 ## Release 0.1.4
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ requires-python = ">=3.11"
 dependencies = [
     "huggingface-hub>=0.33.4",
     "mdtraj>=1.10.3",
-    "mlip>=0.2.2,<0.3.0",
+    "mlip>=0.2.3,<0.3.0",
     "scikit-learn>=1.7.0",
     "streamlit>=1.46.1",
     "vl-convert-python>=1.8.0",
@@ -45,7 +45,7 @@ build-backend = "hatchling.build"
 
 [project.optional-dependencies]
 cuda = [
-    "mlip[cuda13]>=0.2.2,<0.3.0",
+    "mlip[cuda13]>=0.2.3,<0.3.0",
 ]
 
 [dependency-groups]

--- a/src/mlipaudit/utils/simulation.py
+++ b/src/mlipaudit/utils/simulation.py
@@ -25,6 +25,7 @@ from mlip.simulation.configs import ASESimulationConfig
 from mlip.simulation.enums import SimulationType
 from mlip.simulation.jax_md import JaxMDSimulationEngine
 from mlip.simulation.temperature_scheduling import get_temperature_schedule
+from mlip.simulation.utils import resolve_atoms_cell
 
 REUSABLE_BIOMOLECULES_OUTPUTS_ID = ("sampling", "folding_stability")
 
@@ -61,7 +62,7 @@ class ASESimulationEngineWithCalculator(ASESimulationEngine):
         self._num_atoms = positions.shape[0]
         self.state.atomic_numbers = atoms.numbers
 
-        self._init_box()
+        self.atoms = resolve_atoms_cell(self.atoms, self._config.box)
 
         self.is_md_simulation = self._config.simulation_type == SimulationType.MD
         self.is_npt_simulation = (


### PR DESCRIPTION
## Why

`mlip` 0.2.3 (released 2026-07-24) refactored the box/PBC setup out of `ASESimulationEngine`:

| 0.2.2 | 0.2.3 |
|---|---|
| `ASESimulationEngine._init_box()` — private method, mutates `self.atoms` | `mlip.simulation.utils.resolve_atoms_cell(atoms, box) -> ase.Atoms` — public helper |

`ASESimulationEngineWithCalculator` overrides `__init__` instead of `_initialize` (it takes an ASE calculator rather than an mlip `ForceField`), so it reached into the private `self._init_box()`. Our constraint was `mlip>=0.2.2,<0.3.0`, so CI began resolving 0.2.3 and every ASE-calculator simulation started failing:

```
FAILED tests/test_ase_calculator.py::test_benchmarks_can_be_run_with_ase_calculator[FoldingStabilityBenchmark]
AttributeError: 'ASESimulationEngineWithCalculator' object has no attribute '_init_box'
```

This was breaking `tests` on every open PR (#148, #141), not just this branch.

## What

- Use the public `resolve_atoms_cell` helper.
- Raise the `mlip` floor to `>=0.2.3` (both the base dependency and the `cuda` extra) so the symbol is guaranteed present — the fix is not backwards-compatible with 0.2.2, and pinning is what stops CI from flip-flopping between the two.

## Notes

The NEB engine is unaffected — it defines its own `_init_box_neb` locally.

`mlip` 0.2.3's `_initialize` also calls `resolve_atoms_charge_for_model`, which this subclass does not. That is deliberate: the helper gates on `force_field.config.use_total_charge_embedding`, and this class receives an `ase.calculators.Calculator` with no `.config`, so calling it here would raise rather than help. The paths that do have a `ForceField` (`JaxMDSimulationEngine` and the plain `ASESimulationEngine` in `get_simulation_engine` cases 1 and 2) already get that handling for free from mlip itself.

## Testing

Full suite green locally against `mlip==0.2.3` (152 passed), pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)