### PR TITLE
fix: type total charge as int so external calculators accept it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Release 0.1.6
+
+- Set total charges to integers across all benchmarks.
+
 ## Release 0.1.5
 
 - Split the Molecular Liquids benchmarks into four separately scored benchmarks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Release 0.1.6
 
-- Set total charges to integers across all benchmarks.
+- Set total charges to integers across relevant benchmarks.
 
 ## Release 0.1.5
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mlipaudit"
-version = "0.1.5"
+version = "0.1.6"
 description = "Library and CLI tool for benchmarking ML Interatomic Potentials"
 readme = "README.md"
 authors = [

--- a/src/mlipaudit/benchmarks/bond_length_distribution/bond_length_distribution.py
+++ b/src/mlipaudit/benchmarks/bond_length_distribution/bond_length_distribution.py
@@ -69,7 +69,7 @@ class Molecule(BaseModel):
     coordinates: list[tuple[float, float, float]]
     pattern_atom_indices: tuple[int, int]
     reference_bond_distance: float
-    charge: float
+    charge: int
     smiles: str
 
 
@@ -196,7 +196,7 @@ class BondLengthDistributionBenchmark(Benchmark):
                 symbols=molecule.atom_symbols,
                 positions=molecule.coordinates,
             )
-            atoms.info["charge"] = float(molecule.charge)
+            atoms.info["charge"] = molecule.charge
             atoms.info["spin"] = DEFAULT_SPIN
             simulation_state = run_simulation(atoms, self.force_field, **md_kwargs)
 

--- a/src/mlipaudit/benchmarks/conformer_selection/conformer_selection.py
+++ b/src/mlipaudit/benchmarks/conformer_selection/conformer_selection.py
@@ -147,7 +147,7 @@ class Conformer(BaseModel):
     dft_energy_profile: list[float]
     atom_symbols: list[str]
     conformer_coordinates: list[list[tuple[float, float, float]]]
-    charge: float = DEFAULT_CHARGE
+    charge: int = DEFAULT_CHARGE
 
 
 Conformers = TypeAdapter(list[Conformer])
@@ -227,7 +227,7 @@ class ConformerSelectionBenchmark(Benchmark):
                     symbols=structure.atom_symbols,
                     positions=structure.conformer_coordinates[conformer_idx],
                 )
-                atoms.info["charge"] = float(structure.charge)
+                atoms.info["charge"] = structure.charge
                 atoms.info["spin"] = DEFAULT_SPIN
                 all_atoms_list.append(atoms)
                 idx_list.append(i)

--- a/src/mlipaudit/benchmarks/dihedral_scan/dihedral_scan.py
+++ b/src/mlipaudit/benchmarks/dihedral_scan/dihedral_scan.py
@@ -63,7 +63,7 @@ class Fragment(BaseModel):
     atom_symbols: list[str]
     conformer_coordinates: list[list[tuple[float, float, float]]]
     smiles: str
-    charge: float = DEFAULT_CHARGE
+    charge: int = DEFAULT_CHARGE
 
 
 Fragments = TypeAdapter(dict[str, Fragment])
@@ -204,7 +204,7 @@ class DihedralScanBenchmark(Benchmark):
         for fragment_name, fragment in self._torsion_net_500.items():
             for conf_coord in fragment.conformer_coordinates:
                 atoms = Atoms(symbols=fragment.atom_symbols, positions=conf_coord)
-                atoms.info["charge"] = float(fragment.charge)
+                atoms.info["charge"] = fragment.charge
                 atoms.info["spin"] = DEFAULT_SPIN
                 atoms_list_all_structures.append(atoms)
                 structure_indices_map[fragment_name].append(index)

--- a/src/mlipaudit/benchmarks/noncovalent_interactions/noncovalent_interactions.py
+++ b/src/mlipaudit/benchmarks/noncovalent_interactions/noncovalent_interactions.py
@@ -156,7 +156,7 @@ class MolecularSystem(BaseModel):
     system_name: str
     dataset_name: str
     group: str
-    charge: float = Field(alias="total_charge")
+    charge: int = Field(alias="total_charge")
     atom_symbols: list[str]
     coords: list[list[list[float]]]
     distance_profile: list[float]
@@ -413,7 +413,7 @@ class NoncovalentInteractionsBenchmark(Benchmark):
                         symbols=structure.atom_symbols,
                         positions=coord,
                     )
-                    atoms.info["charge"] = float(structure.charge)
+                    atoms.info["charge"] = structure.charge
                     atoms.info["spin"] = DEFAULT_SPIN
                     atoms_all.append(atoms)
                     atoms_all_idx_map[structure.system_id].append(i)

--- a/src/mlipaudit/benchmarks/reactivity/reactivity.py
+++ b/src/mlipaudit/benchmarks/reactivity/reactivity.py
@@ -73,7 +73,7 @@ class Reaction(BaseModel):
     reactants: Molecule
     products: Molecule
     transition_state: Molecule
-    charge: float = DEFAULT_CHARGE
+    charge: int = DEFAULT_CHARGE
 
 
 Reactions = TypeAdapter(dict[str, Reaction])
@@ -210,7 +210,7 @@ class ReactivityBenchmark(Benchmark):
                 positions=reaction_data.transition_state.coordinates,
             )
             for atoms in (reactant_atoms, product_atoms, transition_atoms):
-                atoms.info["charge"] = float(reaction_data.charge)
+                atoms.info["charge"] = reaction_data.charge
                 atoms.info["spin"] = DEFAULT_SPIN
             atoms_list_all.append(reactant_atoms)
             atoms_list_all.append(product_atoms)

--- a/src/mlipaudit/benchmarks/reference_geometry_stability/reference_geometry_stability.py
+++ b/src/mlipaudit/benchmarks/reference_geometry_stability/reference_geometry_stability.py
@@ -83,7 +83,7 @@ class Molecule(BaseModel):
     atom_symbols: list[str]
     coordinates: list[tuple[float, float, float]]
     smiles: str
-    charge: float
+    charge: int
 
 
 Molecules = TypeAdapter(dict[str, Molecule])
@@ -221,7 +221,7 @@ class ReferenceGeometryStabilityBenchmark(Benchmark):
                 atoms = Atoms(
                     symbols=molecule.atom_symbols, positions=molecule.coordinates
                 )
-                atoms.info["charge"] = float(molecule.charge)
+                atoms.info["charge"] = molecule.charge
                 atoms.info["spin"] = DEFAULT_SPIN
                 simulation_state = run_simulation(atoms, self.force_field, **md_kwargs)
 

--- a/src/mlipaudit/benchmarks/ring_planarity/ring_planarity.py
+++ b/src/mlipaudit/benchmarks/ring_planarity/ring_planarity.py
@@ -91,7 +91,7 @@ class Molecule(BaseModel):
     coordinates: list[tuple[float, float, float]]
     smiles: str
     pattern_atoms: list[int]
-    charge: float
+    charge: int
 
 
 Molecules = TypeAdapter(dict[str, Molecule])
@@ -217,7 +217,7 @@ class RingPlanarityBenchmark(Benchmark):
                 symbols=molecule.atom_symbols,
                 positions=molecule.coordinates,
             )
-            atoms.info["charge"] = float(molecule.charge)
+            atoms.info["charge"] = molecule.charge
             atoms.info["spin"] = DEFAULT_SPIN
             simulation_state = run_simulation(atoms, self.force_field, **md_kwargs)
 

--- a/src/mlipaudit/benchmarks/stability/stability.py
+++ b/src/mlipaudit/benchmarks/stability/stability.py
@@ -122,15 +122,15 @@ BOX_SIZES = {
 # Total charge per structure. All systems are treated as closed-shell singlets
 # (spin multiplicity = 1). Values are estimates from system composition and
 # parity-checked against the observed electron count.
-STRUCTURE_CHARGES: dict[str, float] = {
-    "Small_molecule_HCNO": 0.0,
-    "Small_molecule_Sulfur": 0.0,
-    "Small_molecule_Halogen": 0.0,
-    "Peptide_HCNO": 1.0,
-    "Peptide_cys": 0.0,
-    "Protein": 7.0,
-    "Peptide_solvated": 0.0,
-    "Peptide_solvated_ions": 0.0,
+STRUCTURE_CHARGES: dict[str, int] = {
+    "Small_molecule_HCNO": 0,
+    "Small_molecule_Sulfur": 0,
+    "Small_molecule_Halogen": 0,
+    "Peptide_HCNO": 1,
+    "Peptide_cys": 0,
+    "Protein": 7,
+    "Peptide_solvated": 0,
+    "Peptide_solvated_ions": 0,
 }
 
 STRUCTURE_NAMES = list(STRUCTURES.keys())
@@ -435,7 +435,7 @@ class StabilityBenchmark(Benchmark):
             logger.info("Running MD for %s", structure_name)
             xyz_filename = STRUCTURES[structure_name]["xyz"]
             atoms = ase_read(self.data_input_dir / self.name / xyz_filename)
-            atoms.info["charge"] = float(STRUCTURE_CHARGES[structure_name])
+            atoms.info["charge"] = STRUCTURE_CHARGES[structure_name]
             atoms.info["spin"] = DEFAULT_SPIN
 
             if structure_name in BOX_SIZES:

--- a/src/mlipaudit/benchmarks/tautomers/tautomers.py
+++ b/src/mlipaudit/benchmarks/tautomers/tautomers.py
@@ -107,7 +107,7 @@ class TautomerPair(BaseModel):
     energies: list[float]
     coordinates: list[list[list[float]]]
     atom_symbols: list[list[str]]
-    charge: float = DEFAULT_CHARGE
+    charge: int = DEFAULT_CHARGE
 
 
 TautomerPairs = TypeAdapter(dict[str, TautomerPair])
@@ -160,7 +160,7 @@ class TautomersBenchmark(Benchmark):
                 # in case atoms are not in the same order both are present in database:
                 atom_symbols = tautomer_entry.atom_symbols[j]
                 atoms = Atoms(symbols=atom_symbols, positions=coords)
-                atoms.info["charge"] = float(tautomer_entry.charge)
+                atoms.info["charge"] = tautomer_entry.charge
                 atoms.info["spin"] = DEFAULT_SPIN
                 atoms_list_all_structures.append(atoms)
                 structure_name_indices[structure_id].append(i)

--- a/src/mlipaudit/utils/biomolecules.py
+++ b/src/mlipaudit/utils/biomolecules.py
@@ -49,10 +49,10 @@ BOX_SIZES = {
     "villin_capped_solvated": [34.199, 34.199, 34.199],
 }
 
-STRUCTURE_CHARGES: dict[str, float] = {
-    "chignolin_1uao_xray": -2.0,
-    "trp_cage_2jof_xray": 0.0,
-    "villin_capped_solvated": 2.0,
+STRUCTURE_CHARGES: dict[str, int] = {
+    "chignolin_1uao_xray": -2,
+    "trp_cage_2jof_xray": 0,
+    "villin_capped_solvated": 2,
 }
 
 # Energy minimization is run with the JAX-MD FIRE minimizer (GPU-accelerated,
@@ -165,7 +165,7 @@ def iter_biomolecule_simulations(
         logger.info("Running MD for %s", structure_name)
 
         atoms = ase_read(Path(data_dir) / f"{structure_name}.xyz")
-        atoms.info["charge"] = float(STRUCTURE_CHARGES[structure_name])
+        atoms.info["charge"] = STRUCTURE_CHARGES[structure_name]
         atoms.info["spin"] = DEFAULT_SPIN
 
         logger.info("Running energy minimization for %s", structure_name)


### PR DESCRIPTION
## Problem

A system's total charge is physically an integer, but the benchmark input models (`Molecule`, `Fragment`, `Conformer`, `Reaction`, `TautomerPair`, `MolecularSystem`, …) and the two `STRUCTURE_CHARGES` tables typed/stored it as a **float**, and the MD/analysis paths assigned `atoms.info["charge"] = float(...)`.

Native `mlip` force fields tolerate a float charge, but **external ASE calculators** — notably fairchem/UMA's `FAIRChemCalculator` (omol task) — reject it:

```
Invalid type for charge: <class 'float'>. Charge must be an integer representing the total charge on the system.
```

This made **every molecular benchmark** (folding_stability, sampling, stability, NCI, tautomers, …) error out for UMA-S, silently scoring 0.00. NEB already sidesteps this by typing `charge: int`.

## Fix

Type the charge fields and `STRUCTURE_CHARGES` dicts as `int` (pydantic coerces the integral source values at parse time — none of these models use `strict=True`), and drop the now-redundant `float(...)` wrappers at the `atoms.info["charge"] = ...` sites.

- `benchmark.py` unchanged (`DEFAULT_CHARGE: int = 0` already int).
- No behavioural change for native mlip models (they convert the charge to a float array internally regardless).
- Unblocks external calculators that require an integer charge.

## Verification

- `ruff check` / `ruff format` / `mypy` clean on all changed files.
- Runtime sanity: both `STRUCTURE_CHARGES` tables now hold `int`s; `Fragment.charge` / `MolecularSystem.charge` field annotations are `int`; pydantic coerces `-2.0 → -2 (int)`.