### PR TITLE
fix: display the score on the inference speed UI page

### DIFF
--- a/src/mlipaudit/ui/inference_speed.py
+++ b/src/mlipaudit/ui/inference_speed.py
@@ -91,6 +91,11 @@ METRICS: dict[str, dict] = {
 }
 
 
+#: Metric used for the summary table, so that it does not depend on the selector. The
+#: forward pass is engine-independent and is what the score is computed from.
+SUMMARY_METRIC = "Model throughput (atoms/s)"
+
+
 def _structure_time_and_samples(structure, spec: dict) -> tuple:
     """Return ``(central_time_s, [sample_times_s])`` for the metric spec.
 
@@ -363,20 +368,14 @@ def inference_speed_page(
 
     st.markdown("## Summary statistics")
 
-    col_metric, col_scale = st.columns([3, 1])
-    with col_metric:
-        metric_name = st.selectbox("Metric", options=list(METRICS.keys()), index=0)
-    with col_scale:
-        log_scale = st.checkbox("Log–log axes", value=True)
+    df_forward = _process_data_into_dataframe(data, selected_models, SUMMARY_METRIC)
 
-    df = _process_data_into_dataframe(data, selected_models, metric_name)
-
-    if df.empty:
+    if df_forward.empty:
         st.markdown("**No results to display**.")
         return
 
     scores = {model_name: result.score for model_name, result in data.items()}
-    df_summary = _summary_table(df, metric_name, scores)
+    df_summary = _summary_table(df_forward, SUMMARY_METRIC, scores)
     df_summary.sort_values("Score", ascending=False, inplace=True)
     display_model_scores(df_summary)
 
@@ -389,6 +388,18 @@ def inference_speed_page(
     )
 
     st.markdown("## Inference speed: throughput vs system size")
+
+    col_metric, col_scale = st.columns([3, 1])
+    with col_metric:
+        metric_name = st.selectbox("Metric", options=list(METRICS.keys()), index=0)
+    with col_scale:
+        log_scale = st.checkbox("Log–log axes", value=True)
+
+    df = _process_data_into_dataframe(data, selected_models, metric_name)
+
+    if df.empty:
+        st.markdown("**No results to display**.")
+        return
 
     plot_all_models_performance(df, metric_name, log_scale)
 

--- a/src/mlipaudit/ui/inference_speed.py
+++ b/src/mlipaudit/ui/inference_speed.py
@@ -27,6 +27,7 @@ from mlipaudit.benchmarks.inference_speed.inference_speed import (
 from mlipaudit.ui.page_wrapper import UIPageWrapper
 from mlipaudit.ui.utils import (
     display_failed_models,
+    display_model_scores,
     fetch_selected_models,
     filter_failed_results,
     get_failed_models,
@@ -103,6 +104,26 @@ def _structure_time_and_samples(structure, spec: dict) -> tuple:
     if backend is None:
         return None, []
     return backend.average_step_time, list(backend.step_time_samples)
+
+
+def _scores_dataframe(
+    data: BenchmarkResultForMultipleModels, selected_models: list[str]
+) -> pd.DataFrame:
+    """Build the per-model score table.
+
+    Args:
+        data: Mapping from model name to its benchmark result.
+        selected_models: The models currently selected in the sidebar.
+
+    Returns:
+        A DataFrame indexed by model name with a ``Score`` column.
+    """
+    rows = {
+        model_name: {"Score": result.score}
+        for model_name, result in data.items()
+        if model_name in selected_models
+    }
+    return pd.DataFrame.from_dict(rows, orient="index").rename_axis("Model name")
 
 
 def _process_data_into_dataframe(
@@ -345,13 +366,28 @@ def inference_speed_page(
     display_failed_models(failed_models)
     data = filter_failed_results(data)
 
-    st.markdown("## Inference speed: throughput vs system size")
-
     selected_models = fetch_selected_models(available_models=list(data.keys()))
 
     if not selected_models:
         st.markdown("**No results to display**.")
         return
+
+    st.markdown("## Score")
+
+    df_scores = _scores_dataframe(data, selected_models)
+    if not df_scores.empty:
+        df_scores.sort_values("Score", ascending=False, inplace=True)
+        display_model_scores(df_scores)
+        st.caption(
+            "The score rewards fast models: each system contributes a Hill-function "
+            "score on its model forward time relative to the reference time for a "
+            "system of that size, and the benchmark score is the mean over systems. "
+            "It is based on the forward pass (not the MD step) so that it does not "
+            "depend on the simulation engine, and it is wall-clock based — only "
+            "compare models run on the same GPU."
+        )
+
+    st.markdown("## Inference speed: throughput vs system size")
 
     col_metric, col_scale = st.columns([3, 1])
     with col_metric:

--- a/src/mlipaudit/ui/inference_speed.py
+++ b/src/mlipaudit/ui/inference_speed.py
@@ -361,6 +361,8 @@ def inference_speed_page(
         st.markdown("**No results to display**.")
         return
 
+    st.markdown("## Summary statistics")
+
     col_metric, col_scale = st.columns([3, 1])
     with col_metric:
         metric_name = st.selectbox("Metric", options=list(METRICS.keys()), index=0)
@@ -372,8 +374,6 @@ def inference_speed_page(
     if df.empty:
         st.markdown("**No results to display**.")
         return
-
-    st.markdown("## Summary statistics")
 
     scores = {model_name: result.score for model_name, result in data.items()}
     df_summary = _summary_table(df, metric_name, scores)

--- a/src/mlipaudit/ui/inference_speed.py
+++ b/src/mlipaudit/ui/inference_speed.py
@@ -106,26 +106,6 @@ def _structure_time_and_samples(structure, spec: dict) -> tuple:
     return backend.average_step_time, list(backend.step_time_samples)
 
 
-def _scores_dataframe(
-    data: BenchmarkResultForMultipleModels, selected_models: list[str]
-) -> pd.DataFrame:
-    """Build the per-model score table.
-
-    Args:
-        data: Mapping from model name to its benchmark result.
-        selected_models: The models currently selected in the sidebar.
-
-    Returns:
-        A DataFrame indexed by model name with a ``Score`` column.
-    """
-    rows = {
-        model_name: {"Score": result.score}
-        for model_name, result in data.items()
-        if model_name in selected_models
-    }
-    return pd.DataFrame.from_dict(rows, orient="index").rename_axis("Model name")
-
-
 def _process_data_into_dataframe(
     data: BenchmarkResultForMultipleModels,
     selected_models: list[str],
@@ -225,16 +205,22 @@ def _build_fit_lines(df: pd.DataFrame, metric_name: str) -> pd.DataFrame:
     return pd.DataFrame(rows)
 
 
-def _summary_table(df: pd.DataFrame, metric_name: str) -> pd.DataFrame:
-    """Build the per-model summary (scaling exponent, fit quality, throughput).
+def _summary_table(
+    df: pd.DataFrame, metric_name: str, scores: dict[str, float | None]
+) -> pd.DataFrame:
+    """Build the per-model summary (score, scaling exponent, fit quality, throughput).
 
     Args:
         df: The per-structure dataframe.
         metric_name: The metric being plotted (used for the headline value column).
+        scores: The benchmark score per model name.
 
     Returns:
-        A summary dataframe indexed by model name.
+        A summary dataframe indexed by model name, with a ``Score`` column.
     """
+    # The metric column is pre-formatted because `display_model_scores` renders the
+    # whole table with a single precision, which does not suit all metrics.
+    value_format = "{:" + METRICS[metric_name]["format"] + "}"
     rows = []
     for model_name, group in df.groupby("Model name"):
         largest = group.loc[group["Num atoms"].idxmax()]
@@ -249,10 +235,13 @@ def _summary_table(df: pd.DataFrame, metric_name: str) -> pd.DataFrame:
 
         rows.append({
             "Model name": model_name,
+            "Score": scores.get(model_name),
             "Graph cutoff (Å)": group["Graph cutoff (Å)"].iloc[0],
             "Scaling exponent (time ∝ Nᵏ)": exponent_str,
             "R²": r_squared_str,
-            f"{metric_name} @ largest system": largest[metric_name],
+            f"{metric_name} @ largest system": value_format.format(
+                largest[metric_name]
+            ),
             "Largest system (atoms)": int(largest["Num atoms"]),
         })
     return pd.DataFrame(rows).set_index("Model name")
@@ -372,23 +361,6 @@ def inference_speed_page(
         st.markdown("**No results to display**.")
         return
 
-    st.markdown("## Score")
-
-    df_scores = _scores_dataframe(data, selected_models)
-    if not df_scores.empty:
-        df_scores.sort_values("Score", ascending=False, inplace=True)
-        display_model_scores(df_scores)
-        st.caption(
-            "The score rewards fast models: each system contributes a Hill-function "
-            "score on its model forward time relative to the reference time for a "
-            "system of that size, and the benchmark score is the mean over systems. "
-            "It is based on the forward pass (not the MD step) so that it does not "
-            "depend on the simulation engine, and it is wall-clock based — only "
-            "compare models run on the same GPU."
-        )
-
-    st.markdown("## Inference speed: throughput vs system size")
-
     col_metric, col_scale = st.columns([3, 1])
     with col_metric:
         metric_name = st.selectbox("Metric", options=list(METRICS.keys()), index=0)
@@ -401,6 +373,23 @@ def inference_speed_page(
         st.markdown("**No results to display**.")
         return
 
+    st.markdown("## Summary statistics")
+
+    scores = {model_name: result.score for model_name, result in data.items()}
+    df_summary = _summary_table(df, metric_name, scores)
+    df_summary.sort_values("Score", ascending=False, inplace=True)
+    display_model_scores(df_summary)
+
+    st.caption(
+        "The score rewards fast models: each system contributes a Hill-function score "
+        "on its model forward time relative to the reference time for a system of that "
+        "size, and the benchmark score is the mean over systems. It is based on the "
+        "forward pass (not the MD step) so that it does not depend on the simulation "
+        "engine."
+    )
+
+    st.markdown("## Inference speed: throughput vs system size")
+
     plot_all_models_performance(df, metric_name, log_scale)
 
     st.caption(
@@ -409,13 +398,6 @@ def inference_speed_page(
         "metric includes neighbour-list construction, whereas for mlip models it is "
         "the pure network forward. All times are wall-clock and hardware-relative — "
         "only compare models run on the same GPU."
-    )
-
-    st.markdown("### Summary")
-    metric_column = f"{metric_name} @ largest system"
-    metric_format = "{:" + METRICS[metric_name]["format"] + "}"
-    st.dataframe(
-        _summary_table(df, metric_name).style.format({metric_column: metric_format})
     )
 
 


### PR DESCRIPTION
## Description

The inference speed page was the only benchmark page that never displayed
`result.score`. Fold the score into a single `Summary statistics` table at the
top of the page (score first, colour-coded via `display_model_scores`), as on
the other benchmark pages, replacing the summary that sat at the bottom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
