### PR TITLE
fix: cap the charts in the NVE energy conservation UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Release 0.1.7
+
+- Cap the total-energy drift charts on the `nve_energy_conservation` UI page so
+  that a diverging model no longer flattens every other curve onto zero.
+
 ## Release 0.1.6
 
 - Remove the TM-score from the `folding_stability` score.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mlipaudit"
-version = "0.1.6"
+version = "0.1.7"
 description = "Library and CLI tool for benchmarking ML Interatomic Potentials"
 readme = "README.md"
 authors = [

--- a/src/mlipaudit/ui/nve_energy_conservation.py
+++ b/src/mlipaudit/ui/nve_energy_conservation.py
@@ -36,6 +36,9 @@ BenchmarkResultForMultipleModels: TypeAlias = dict[
     ModelName, NVEEnergyConservationResult
 ]
 
+DRIFT_DOMAIN_MARGIN = 10.0
+DRIFT_CAP_EV_PER_ATOM = 0.4
+
 
 def _scores_dataframe(
     data: BenchmarkResultForMultipleModels, selected_models: list[str]
@@ -98,6 +101,44 @@ def _drift_dataframe(
                     "Kind": "Linear fit",
                 })
     return pd.DataFrame(records)
+
+
+def _robust_drift_domain(
+    df: pd.DataFrame, num_atoms: int | None = None
+) -> list[float] | None:
+    """Compute a y-axis domain that a single diverging model cannot dominate.
+
+    The axis is left to auto-scale while every curve stays under a ceiling of
+    ``DRIFT_CAP_EV_PER_ATOM * num_atoms`` -- the drift is an extensive quantity,
+    so a larger system tolerates a larger drift. Past that ceiling the axis is
+    bounded by the tighter of the ceiling itself and ``DRIFT_DOMAIN_MARGIN``
+    times the median per-model peak drift, which keeps the chart readable both
+    when one model blows up by orders of magnitude (the median ignores it) and
+    when most of them drift badly (the ceiling still bounds the axis).
+
+    Args:
+        df: The long-format drift dataframe.
+        num_atoms: The number of atoms in the plotted system. When ``None``, only
+                   the median bound applies.
+
+    Returns:
+        The ``[lower, upper]`` domain, or ``None`` to leave the axis auto-scaled.
+    """
+    drift = df.loc[df["Kind"] == "Drift", "Drift (eV)"].abs()
+    if drift.empty:
+        return None
+
+    cap = DRIFT_CAP_EV_PER_ATOM * num_atoms if num_atoms else None
+    peak = float(drift.max())
+    if cap is not None and peak <= cap:
+        return None
+
+    limit = float(drift.groupby(df["Model"]).max().median()) * DRIFT_DOMAIN_MARGIN
+    if cap is not None:
+        limit = min(cap, limit)
+    if limit <= 0.0 or peak <= limit:
+        return None
+    return [-limit, limit]
 
 
 def _system_metrics_dataframe(
@@ -210,23 +251,39 @@ def nve_energy_conservation_page(
         st.markdown("**No drift curves to display**.")
         return
 
-    system_name = st.selectbox(
-        "Select a system",
-        available_systems,
-        format_func=lambda name: name.replace("_", " "),
-    )
+    col_system, col_range = st.columns([3, 1])
+    with col_system:
+        system_name = st.selectbox(
+            "Select a system",
+            available_systems,
+            format_func=lambda name: name.replace("_", " "),
+        )
+    with col_range:
+        show_full_range = st.checkbox("Show full drift range", value=False)
 
     df_drift = _drift_dataframe(data, selected_models, system_name)
     if df_drift.empty:
         st.markdown("**No drift curves to display for the selected models**.")
         return
 
+    num_atoms = next(
+        (
+            structure.num_atoms
+            for result in data.values()
+            for structure in result.structure_results
+            if structure.structure_name == system_name and structure.num_atoms
+        ),
+        None,
+    )
+    domain = None if show_full_range else _robust_drift_domain(df_drift, num_atoms)
+    y_scale = alt.Scale(domain=domain) if domain else alt.Scale()
+
     chart = (
         alt.Chart(df_drift)
-        .mark_line()
+        .mark_line(clip=True)
         .encode(
             x=alt.X("Time (ps):Q", title="Time (ps)"),
-            y=alt.Y("Drift (eV):Q", title="Total-energy drift ΔE (eV)"),
+            y=alt.Y("Drift (eV):Q", title="Total-energy drift ΔE (eV)", scale=y_scale),
             color=alt.Color("Model:N", title="Model"),
             # Solid = drift, dashed = linear fit (explained in the text above). No
             # separate legend for this: a second stacked legend squeezes the
@@ -236,6 +293,18 @@ def nve_energy_conservation_page(
         .properties(width=800, height=400)
     )
     st.altair_chart(chart, width="stretch")
+
+    if domain:
+        off_axis = (df_drift["Kind"] == "Drift") & (
+            df_drift["Drift (eV)"].abs() > domain[1]
+        )
+        if off_axis.any():
+            st.caption(
+                f"The y-axis is limited to ±{domain[1]:.4g} eV so that the "
+                "well-conserving models stay readable. Curves that leave the axis: "
+                f"{', '.join(sorted(df_drift.loc[off_axis, 'Model'].unique()))}. "
+                "Tick *Show full drift range* to see them."
+            )
 
     df_metrics = _system_metrics_dataframe(data, selected_models, system_name)
     if not df_metrics.empty:

--- a/src/mlipaudit/ui/nve_energy_conservation.py
+++ b/src/mlipaudit/ui/nve_energy_conservation.py
@@ -103,9 +103,7 @@ def _drift_dataframe(
     return pd.DataFrame(records)
 
 
-def _robust_drift_domain(
-    df: pd.DataFrame, num_atoms: int | None = None
-) -> list[float] | None:
+def _robust_drift_domain(df: pd.DataFrame, num_atoms: int | None) -> list[float] | None:
     """Compute a y-axis domain that a single diverging model cannot dominate.
 
     The axis is left to auto-scale while every curve stays under a ceiling of
@@ -118,27 +116,26 @@ def _robust_drift_domain(
 
     Args:
         df: The long-format drift dataframe.
-        num_atoms: The number of atoms in the plotted system. When ``None``, only
-                   the median bound applies.
+        num_atoms: The number of atoms in the plotted system, which sets the
+                   ceiling. Without it there is no scale to judge the drift
+                   against, so the axis is left alone.
 
     Returns:
         The ``[lower, upper]`` domain, or ``None`` to leave the axis auto-scaled.
     """
+    if df.empty or not num_atoms:
+        return None
+
     drift = df.loc[df["Kind"] == "Drift", "Drift (eV)"].abs()
     if drift.empty:
         return None
 
-    cap = DRIFT_CAP_EV_PER_ATOM * num_atoms if num_atoms else None
-    peak = float(drift.max())
-    if cap is not None and peak <= cap:
+    cap = DRIFT_CAP_EV_PER_ATOM * num_atoms
+    if float(drift.max()) <= cap:
         return None
 
     limit = float(drift.groupby(df["Model"]).max().median()) * DRIFT_DOMAIN_MARGIN
-    if cap is not None:
-        limit = min(cap, limit)
-    if limit <= 0.0 or peak <= limit:
-        return None
-    return [-limit, limit]
+    return [-limit, limit] if 0.0 < limit < cap else [-cap, cap]
 
 
 def _system_metrics_dataframe(
@@ -295,16 +292,13 @@ def nve_energy_conservation_page(
     st.altair_chart(chart, width="stretch")
 
     if domain:
-        off_axis = (df_drift["Kind"] == "Drift") & (
-            df_drift["Drift (eV)"].abs() > domain[1]
+        off_axis = df_drift["Drift (eV)"].abs() > domain[1]
+        st.caption(
+            f"The y-axis is limited to ±{domain[1]:.4g} eV so that the "
+            "well-conserving models stay readable. Curves that leave the axis: "
+            f"{', '.join(sorted(df_drift.loc[off_axis, 'Model'].unique()))}. "
+            "Tick *Show full drift range* to see them."
         )
-        if off_axis.any():
-            st.caption(
-                f"The y-axis is limited to ±{domain[1]:.4g} eV so that the "
-                "well-conserving models stay readable. Curves that leave the axis: "
-                f"{', '.join(sorted(df_drift.loc[off_axis, 'Model'].unique()))}. "
-                "Tick *Show full drift range* to see them."
-            )
 
     df_metrics = _system_metrics_dataframe(data, selected_models, system_name)
     if not df_metrics.empty:


### PR DESCRIPTION
## Problem

On the *NVE energy conservation* page, a model that blows up during the run drifts by orders of magnitude more than the rest. Altair auto-scales the y-axis of the total-energy drift chart to that outlier — ~9e5 eV for `Peptide_solvated` and ~3e36 eV for `Water_box_n500` — which squashes every other model's curve onto the zero line, so the chart says nothing about the models that actually conserve energy.

## Fix

The axis is bounded by a hard ceiling scaled by system size: the drift is an extensive quantity, so the ceiling is an allowance per atom (`DRIFT_CAP_EV_PER_ATOM = 0.4`) applied to the atom count already recorded on each structure result.

| System | Atoms | Ceiling | Data max | Y-axis | Models clipped |
| --- | --- | --- | --- | --- | --- |
| `Small_molecule_HCNO` | 46 | 18 eV | 0.08 eV | auto | 0/14 |
| `Peptide_solvated` | 1349 | 540 eV | 8.9e5 eV | ±26.5 eV | 2/14 |
| `Water_box_n500` | 1503 | 601 eV | 2.9e36 eV | ±28.0 eV | 4/14 |
| `Peptide_solvated_ions` | 2642 | 1057 eV | 188 eV | auto | 0/14 |

While every curve fits under the ceiling the axis auto-scales exactly as before, so a system whose models merely differ by a factor of a few keeps its full range on show. Past the ceiling the axis is bounded by the tighter of the ceiling and `DRIFT_DOMAIN_MARGIN = 10.0` times the median per-model peak drift — a median ignores a couple of diverging models, so at least half stay fully visible, while the ceiling still bounds the axis when *most* models drift badly. Results written before the atom count was recorded fall back to the median bound alone.

The lines are drawn with `clip=True` so a diverging curve runs off the top of the chart instead of rescaling it, a **"Show full drift range"** checkbox restores the unbounded axis, and a caption names the models whose curves leave the axis so a clipped curve is never silently hidden.

## Testing

- `pytest tests/test_ui_pages.py` passes; pre-commit (ruff + mypy) clean.
- Checked the axis rule against the live results for all four systems (table above) and against the edge cases: every curve under the ceiling, one model diverging (with and without an atom count), every model drifting past the ceiling, all-zero drift, and a frame carrying no drift rows.
- Ran the GUI side by side against the same results directory to compare the before/after chart.